### PR TITLE
Fixed #7 SEO metabox doesn't collapse

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,3 @@
-#fw-options-box-seo .inside {
+.postbox-with-fw-options .inside {
 	display: block;
 }


### PR DESCRIPTION
This will turn out specificity selector to 0010 allowing the postbox to be collapsable.